### PR TITLE
fix(DEV-60): fix pagination button count display

### DIFF
--- a/src/pages/CatalogPage/CatalogPage.tsx
+++ b/src/pages/CatalogPage/CatalogPage.tsx
@@ -243,6 +243,7 @@ export const CatalogPage: React.FC = () => {
               <PaginationButton
                 onClick={handlePrevious}
                 disabled={pageParam === 1}
+                isArrow
               >
                 <ArrowLeftIcon />
               </PaginationButton>
@@ -254,6 +255,7 @@ export const CatalogPage: React.FC = () => {
               <PaginationButton
                 onClick={handleNext}
                 disabled={pageParam === pageCount}
+                isArrow
               >
                 <ArrowRightIcon />
               </PaginationButton>

--- a/src/pages/CatalogPage/CatalogPage.tsx
+++ b/src/pages/CatalogPage/CatalogPage.tsx
@@ -124,11 +124,11 @@ export const CatalogPage: React.FC = () => {
       1,
       currentPageIndex - Math.floor(visiblePagesCount / 2),
     );
-    let endPageIndex = startPageIndex + visiblePagesCount;
+    let endPageIndex = startPageIndex + visiblePagesCount - 1;
 
     if (endPageIndex > totalPageCount) {
       endPageIndex = totalPageCount;
-      startPageIndex = Math.max(1, endPageIndex - visiblePagesCount);
+      startPageIndex = Math.max(1, endPageIndex - visiblePagesCount + 1);
     }
 
     const renderedPages = [];

--- a/src/pages/CatalogPage/CatalogPage.tsx
+++ b/src/pages/CatalogPage/CatalogPage.tsx
@@ -247,7 +247,9 @@ export const CatalogPage: React.FC = () => {
                 <ArrowLeftIcon />
               </PaginationButton>
 
-              {renderPageNumbers()}
+              <div className="catalog-page__pagination-numbers">
+                {renderPageNumbers()}
+              </div>
 
               <PaginationButton
                 onClick={handleNext}

--- a/src/ui/components/PaginationButton/PaginationButton.scss
+++ b/src/ui/components/PaginationButton/PaginationButton.scss
@@ -28,5 +28,11 @@
       color: var(--white-color);
       transition: 0.3s ease;
     }
+
+    &:disabled {
+      border: 1px solid var(--elements-color);
+      color: var(--icons-color);
+      cursor: not-allowed;
+    }
   }
 }

--- a/src/ui/components/PaginationButton/PaginationButton.scss
+++ b/src/ui/components/PaginationButton/PaginationButton.scss
@@ -17,6 +17,11 @@
       transition: 0.3s ease;
     }
 
+    &-arrow {
+      border: 1px solid var(--icons-color);
+      color: var(--primary-color);
+    }
+
     &-selected {
       background-color: var(--primary-color);
       border: 1px solid var(--primary-color);

--- a/src/ui/components/PaginationButton/PaginationButton.tsx
+++ b/src/ui/components/PaginationButton/PaginationButton.tsx
@@ -7,6 +7,7 @@ type PaginationButtonProps = {
   children?: React.ReactNode;
   onClick?: () => void;
   disabled?: boolean;
+  isArrow?: boolean;
 };
 
 export const PaginationButton: React.FC<PaginationButtonProps> = ({
@@ -14,6 +15,7 @@ export const PaginationButton: React.FC<PaginationButtonProps> = ({
   children = 'Button',
   onClick,
   disabled = false,
+  isArrow = false,
 }) => {
   return (
     <button
@@ -26,6 +28,7 @@ export const PaginationButton: React.FC<PaginationButtonProps> = ({
         'typography--buttons',
         {
           'button--pagination-selected': selected,
+          'button--pagination-arrow': isArrow,
         },
       )}
       onClick={onClick}


### PR DESCRIPTION
Ensures exactly 4 pagination buttons are always shown (except when perPage = All)
Adds proper spacing between page numbers (8px) and arrows (16px)
Adds correct border color for arrow buttons
Implements disabled state styles for navigation arrows on first/last pages